### PR TITLE
fix a few things clippy found

### DIFF
--- a/examples/buggy_write.rs
+++ b/examples/buggy_write.rs
@@ -98,7 +98,7 @@ fn main() {
 }
 
 mod test {
-    //! Tests to demonstrate how to use partial-io to catch bugs in buggy_write.
+    //! Tests to demonstrate how to use partial-io to catch bugs in `buggy_write`.
 
     // * 'cargo test' doesn't support running tests inside examples.
     // * We'd like to make it possible to run this example to test it out.


### PR DESCRIPTION
Use the `Default` trait rather than defining our own `new` function. Pretty neat!

Fix a couple of other misc things.